### PR TITLE
Update to ES6 and Node.js version >= 4.1.0 (post Node/iojs merger)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 Dale Schumacher, Tristan Slominski
+Copyright (c) 2013-2015 Dale Schumacher, Tristan Slominski
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The goal of `tart` is to provide the smallest possible actor library in JavaScri
   * [Benchmarks](#benchmarks)
   * [Documentation](#documentation)
     * [Tweet](#tweet)
+    * [ES6Tweet](#es6tweet)
     * [Minimal](#minimal)
     * [Pluggable](#pluggable)
   * [Sources](#sources)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ For rings of sizes larger than 4 Million you may need to expand memory available
 The [Minimal](#minimal) implementation is the implementation optimized for fastest execution time. In contrast, [Pluggable](#pluggable) implementation allows for total control of the runtime and execution semantics. Although the default behavior of [Pluggable](#pluggable) is the same as [Minimal](#minimal), it is somewhat slower due to extra overhead incurred by pluggability of control and observability mechanisms.
 
   * [Tweet](#tweet)
+  * [ES6Tweet](#es6Tweet)
   * [Minimal](#minimal)
   * [Pluggable](#pluggable)
 
@@ -198,23 +199,43 @@ The [Minimal](#minimal) implementation is the implementation optimized for faste
 
 Creates a sponsor capability to create new actors with using the Tweetable implementation :D.
 
-WARNING: If an exception is thrown during message processing the Tweetable run-time will crash. For fastest stable implementation use [Minimal](#minimal).
+WARNING: If an exception is thrown during message processing the Tweetable run-time will crash. For fastest stable implementation use [ES6Tweet](#es6tweet).
 
 ### sponsor(behavior)
 
-Same as the core [Minimal](#minimal) implementation. _See: [sponsor(behavior)](#sponsorbehavior-1)_
+Same as the core [Minimal](#minimal) implementation. _See: [sponsor(behavior)](#sponsorbehavior-2)_
 
 ### actor(message)
 
-Same as the core [Minimal](#minimal) implementation. _See: [actor(message)](#actormessage-1)_
+Same as the core [Minimal](#minimal) implementation. _See: [actor(message)](#actormessage-2)_
+
+### ES6Tweet
+
+**Public API**
+
+  * [tart.es6Tweet()](#tartes6tweet)
+  * [sponsor(behavior)](#sponsorbehavior-1)
+  * [actor(message)](#actormessage-1)
+
+### tart.es6Tweet()
+
+Creates a sponsor capability to create new actors with using the ES6 Tweetable (and non-crashing) implementation :D.
+
+### sponsor(behavior)
+
+Same as the core [Minimal](#minimal) implementation. _See: [sponsor(behavior)](#sponsorbehavior-2)_
+
+### actor(message)
+
+Same as the core [Minimal](#minimal) implementation. _See: [actor(message)](#actormessage-2)_
 
 ### Minimal
 
 **Public API**
 
   * [tart.minimal(\[options\])](#tartminimaloptions)
-  * [sponsor(behavior)](#sponsorbehavior-1)
-  * [actor(message)](#actormessage-1)
+  * [sponsor(behavior)](#sponsorbehavior-2)
+  * [actor(message)](#actormessage-2)
 
 ### tart.minimal([options])
 
@@ -279,8 +300,8 @@ actor('hello actor world');
 **Public API**
 
   * [tart.pluggable(\[options\])](#tartpluggableoptions)
-  * [sponsor(behavior)](#sponsorbehavior-2)
-  * [actor(message)](#actormessage-2)
+  * [sponsor(behavior)](#sponsorbehavior-3)
+  * [actor(message)](#actormessage-3)
 
 ### tart.pluggable([options])
 
@@ -347,11 +368,11 @@ actor('foo');
 
 ### sponsor(behavior)
 
-Same as the core [Minimal](#minimal) implementation. _See: [sponsor(behavior)](#sponsorbehavior-1)_
+Same as the core [Minimal](#minimal) implementation. _See: [sponsor(behavior)](#sponsorbehavior-2)_
 
 ### actor(message)
 
-Same as the core [Minimal](#minimal) implementation. _See: [actor(message)](#actormessage-1)_
+Same as the core [Minimal](#minimal) implementation. _See: [actor(message)](#actormessage-2)_
 
 ## Sources
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ For rings of sizes larger than 4 Million you may need to expand memory available
 The [Minimal](#minimal) implementation is the implementation optimized for fastest execution time. In contrast, [Pluggable](#pluggable) implementation allows for total control of the runtime and execution semantics. Although the default behavior of [Pluggable](#pluggable) is the same as [Minimal](#minimal), it is somewhat slower due to extra overhead incurred by pluggability of control and observability mechanisms.
 
   * [Tweet](#tweet)
-  * [ES6Tweet](#es6Tweet)
+  * [ES6Tweet](#es6tweet)
   * [Minimal](#minimal)
   * [Pluggable](#pluggable)
 

--- a/README.md
+++ b/README.md
@@ -214,13 +214,16 @@ Same as the core [Minimal](#minimal) implementation. _See: [actor(message)](#act
 
 **Public API**
 
-  * [tart.es6Tweet()](#tartes6tweet)
+  * [tart.es6Tweet(fail)](#tartes6tweetfail)
   * [sponsor(behavior)](#sponsorbehavior-1)
   * [actor(message)](#actormessage-1)
 
-### tart.es6Tweet()
+### tart.es6Tweet(fail)
 
-Creates a sponsor capability to create new actors with using the ES6 Tweetable (and non-crashing) implementation :D.
+  * `fail`: _Function_ _(Default: `undefined`)_ `function (exception) {}` An optional handler to call if a sponsored actor behavior throws an exception.
+  * Return: _Function_ `function (behavior) {}` A capability to create new actors.
+
+Creates a sponsor capability to create new actors using the ES6 Tweetable implementation :D.
 
 ### sponsor(behavior)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The goal of `tart` is to provide the smallest possible actor library in JavaScri
 
 If you use ES6 it's even smaller with an additional feature of optional failure handler `f` to handle situations when behaviors throw exceptions ;)
 
-    (f)=>{let s=(b)=>{let a=(m)=>{setImmediate(()=>{try{x.behavior(m)}catch(e){f&&f(e)}})},x={self:a,behavior:b,sponsor:s};return a};return s};
+    (f)=>{let c=(b)=>{let a=(m)=>{setImmediate(()=>{try{x.behavior(m)}catch(e){f&&f(e)}})},x={self:a,behavior:b,sponsor:c};return a};return c};
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The goal of `tart` is to provide the smallest possible actor library in JavaScri
   * [Modules](#modules)
   * [Usage](#usage)
   * [Tests](#tests)
-  * [Benchmarks](#benchmarks) 
+  * [Benchmarks](#benchmarks)
   * [Documentation](#documentation)
     * [Tweet](#tweet)
     * [Minimal](#minimal)
@@ -27,6 +27,10 @@ The goal of `tart` is to provide the smallest possible actor library in JavaScri
 `tart` happens to fit into a tweet :D
 
     function(){var c=function(b){var a=function(m){setImmediate(function(){x.behavior(m)})},x={self:a,behavior:b,sponsor:c};return a};return c}
+
+If you use ES6 it's even smaller with an additional feature of not crashing when behaviors throw exceptions ;)
+
+    ()=>{let c=(b)=>{let a=(m)=>{setImmediate(()=>{try{x.behavior(m)}catch(e){}})},x={self:a,behavior:b,sponsor:c};return a};return c};
 
 ## Modules
 
@@ -62,7 +66,7 @@ var sponsor = tart.minimal();
 
 // create an actor that has no state
 var statelessActor = sponsor(function (message) {
-    console.log('got message', message); 
+    console.log('got message', message);
 });
 
 // create an actor with state
@@ -100,7 +104,7 @@ var chainActorBeh = function (count) {
             var next = this.sponsor(chainActorBeh(count));
             next(message);
         }
-    }; 
+    };
 };
 
 var chainActor = sponsor(chainActorBeh(10));
@@ -125,7 +129,7 @@ Benchmarks were run on the [Minimal](#minimal) implementation.
 
 ### Erlang Challenge
 
-Erlang Challenge consists of creating a ring of M actors, sending N simple messages around the ring and increasing M until running out of resources. 
+Erlang Challenge consists of creating a ring of M actors, sending N simple messages around the ring and increasing M until running out of resources.
 
 The benchmark implements a modified version of the challenge by creating 100,000 actors and running 10 simple messages around the ring.
 
@@ -242,7 +246,7 @@ Creates a new actor and returns the actor reference in form of a capability to s
 var tart = require('tart');
 var sponsor = tart.minimal();
 var actor = sponsor(function (message) {
-    console.log('got message', message); 
+    console.log('got message', message);
     console.log(this.self);
     console.log(this.behavior);
     console.log(this.sponsor);
@@ -283,8 +287,8 @@ actor('hello actor world');
   * `options`: _Object_ _(Default: undefined)_ Optional overrides.
     * `constructConfig`: _Function_ _(Default: `function (options) {}`)_ `function (options) {}` Configuration creation function that is given `options`. It should return a capability `function (behavior) {}` to create new actors.
     * `deliver`: _Function_ _(Default: `function (context, message, options) {}`)_ `function (context, message, options) {}` Deliver function that returns a function for `dispatch` to dispatch.
-    * `dispatch`: _Function_ _(Default: `setImmediate`)_ `function (deliver) {}` Dispatch function for dispatching `deliver` closures. 
-    * `fail`: _Function_ _(Default: `function (exception) {}`)_ `function (exception) {}` An optional handler to call if a sponsored actor behavior throws an exception.  
+    * `dispatch`: _Function_ _(Default: `setImmediate`)_ `function (deliver) {}` Dispatch function for dispatching `deliver` closures.
+    * `fail`: _Function_ _(Default: `function (exception) {}`)_ `function (exception) {}` An optional handler to call if a sponsored actor behavior throws an exception.
   * Return: _Function_ `function (behavior) {}` A capability to create new actors.
 
 Creates a sponsor capability to create new actors with and allows replacing parts of the implementation.
@@ -297,8 +301,8 @@ To run the below example run:
 var tart = require('tart');
 
 var dispatch = function (deliver) {
-    console.log('delivering a message'); 
-    deliver(); 
+    console.log('delivering a message');
+    deliver();
 };
 
 var deliver = function deliver(context, message, options) {

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ The goal of `tart` is to provide the smallest possible actor library in JavaScri
 
     function(){var c=function(b){var a=function(m){setImmediate(function(){x.behavior(m)})},x={self:a,behavior:b,sponsor:c};return a};return c}
 
-If you use ES6 it's even smaller with an additional feature of not crashing when behaviors throw exceptions ;)
+If you use ES6 it's even smaller with an additional feature of optional failure handler `f` to handle situations when behaviors throw exceptions ;)
 
-    ()=>{let c=(b)=>{let a=(m)=>{setImmediate(()=>{try{x.behavior(m)}catch(e){}})},x={self:a,behavior:b,sponsor:c};return a};return c};
+    (f)=>{let s=(b)=>{let a=(m)=>{setImmediate(()=>{try{x.behavior(m)}catch(e){f&&f(e)}})},x={self:a,behavior:b,sponsor:s};return a};return s};
 
 ## Modules
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ index.js - "tartjs": Tiny Actor Run-Time in JavaScript
 
 The MIT License (MIT)
 
-Copyright (c) 2013 Dale Schumacher, Tristan Slominski
+Copyright (c) 2013-2015 Dale Schumacher, Tristan Slominski
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
@@ -34,9 +34,11 @@ var tart = module.exports;
 
 tart.tweet = function(){var c=function(b){var a=function(m){setImmediate(function(){x.behavior(m)})},x={self:a,behavior:b,sponsor:c};return a};return c};
 
+tart.es6Tweet = ()=>{let c=(b)=>{let a=(m)=>{setImmediate(()=>{try{x.behavior(m)}catch(e){}})},x={self:a,behavior:b,sponsor:c};return a};return c};
+
 /*
   * `options`: _Object_ _(Default: undefined)_
-    * `fail`: _Function_ _(Default: `function (exception) {}`)_ 
+    * `fail`: _Function_ _(Default: `function (exception) {}`)_
         `function (exception) {}` An optional handler to call if a sponsored actor
         behavior throws an exception.
   * Return: _Function_ `function (behavior) {}` A capability to create new actors.
@@ -49,16 +51,16 @@ tart.minimal = function config(options) {
     var fail = options.fail || function (exception) {};
 
     /*
-      * `behavior`: _Function_ `function (message) {}` Actor behavior to 
+      * `behavior`: _Function_ `function (message) {}` Actor behavior to
           invoke every time an actor receives a message.
-      * Return: _Function_ `function (message) {}` Actor reference that can be 
-          invoked to send the actor a message.            
+      * Return: _Function_ `function (message) {}` Actor reference that can be
+          invoked to send the actor a message.
 
       Creates a new actor and returns the actor reference in form of a capability
-      to send that actor a message.      
+      to send that actor a message.
     */
     var sponsor = function create(behavior) {
-        
+
         /*
           * `message`: _Any_ Any message.
 
@@ -85,19 +87,19 @@ tart.minimal = function config(options) {
 
 /*
   * `options`: _Object_ _(Default: undefined)_ Optional overrides.
-    * `constructConfig`: _Function_ _(Default: `function (options) {}`)_ 
-        `function (options) {}` Configuration creation function that 
-        is given `options`. It should return a capability `function (behavior) {}` 
+    * `constructConfig`: _Function_ _(Default: `function (options) {}`)_
+        `function (options) {}` Configuration creation function that
+        is given `options`. It should return a capability `function (behavior) {}`
         to create new actors.
-    * `deliver`: _Function_ _(Default: `function (context, message, options) {}`)_ 
-        `function (context, message, options) {}` Deliver function that returns 
+    * `deliver`: _Function_ _(Default: `function (context, message, options) {}`)_
+        `function (context, message, options) {}` Deliver function that returns
         a function for `dispatch` to dispatch.
-    * `dispatch`: _Function_ _(Default: `setImmediate`)_ 
-        `function (deliver) {}` Dispatch function for dispatching `deliver` 
-        closures. 
-    * `fail`: _Function_ _(Default: `function (exception) {}`)_ 
+    * `dispatch`: _Function_ _(Default: `setImmediate`)_
+        `function (deliver) {}` Dispatch function for dispatching `deliver`
+        closures.
+    * `fail`: _Function_ _(Default: `function (exception) {}`)_
         `function (exception) {}` An optional handler to call if a sponsored actor
-        behavior throws an exception. 
+        behavior throws an exception.
   * Return: _Function_ `function (behavior) {}` A capability to create new actors.
 
   Creates a sponsor capability to create new actors with and allows replacing

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ index.js - "tartjs": Tiny Actor Run-Time in JavaScript
 
 The MIT License (MIT)
 
-Copyright (c) 2013-2015 Dale Schumacher, Tristan Slominski
+Copyright (c) 2013-2016 Dale Schumacher, Tristan Slominski
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
@@ -34,7 +34,7 @@ var tart = module.exports;
 
 tart.tweet = function(){var c=function(b){var a=function(m){setImmediate(function(){x.behavior(m)})},x={self:a,behavior:b,sponsor:c};return a};return c};
 
-tart.es6Tweet = (f)=>{let s=(b)=>{let a=(m)=>{setImmediate(()=>{try{x.behavior(m)}catch(e){f&&f(e)}})},x={self:a,behavior:b,sponsor:s};return a};return s};
+tart.es6Tweet = (f)=>{let c=(b)=>{let a=(m)=>{setImmediate(()=>{try{x.behavior(m)}catch(e){f&&f(e)}})},x={self:a,behavior:b,sponsor:c};return a};return c};
 
 /*
   * `options`: _Object_ _(Default: undefined)_

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ var tart = module.exports;
 
 tart.tweet = function(){var c=function(b){var a=function(m){setImmediate(function(){x.behavior(m)})},x={self:a,behavior:b,sponsor:c};return a};return c};
 
-tart.es6Tweet = ()=>{let c=(b)=>{let a=(m)=>{setImmediate(()=>{try{x.behavior(m)}catch(e){}})},x={self:a,behavior:b,sponsor:c};return a};return c};
+tart.es6Tweet = (f)=>{let s=(b)=>{let a=(m)=>{setImmediate(()=>{try{x.behavior(m)}catch(e){f&&f(e)}})},x={self:a,behavior:b,sponsor:s};return a};return s};
 
 /*
   * `options`: _Object_ _(Default: undefined)_

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "main": "index.js",
   "devDependencies": {
-    "nodeunit": "0.8.x"
+    "nodeunit": "0.9.x"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "test": "node scripts/test.js"
   },
   "main": "index.js",
+  "engines": {
+    "node": ">=4.1.0"
+  },
   "devDependencies": {
     "nodeunit": "0.9.x"
   },

--- a/test/crash.js
+++ b/test/crash.js
@@ -4,7 +4,7 @@ crash.js - actor crash test
 
 The MIT License (MIT)
 
-Copyright (c) 2013 Dale Schumacher, Tristan Slominski
+Copyright (c) 2013-2015 Dale Schumacher, Tristan Slominski
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
@@ -33,6 +33,33 @@ OTHER DEALINGS IN THE SOFTWARE.
 var tart = require('../index.js');
 
 var test = module.exports = {};
+
+test['actor crash should not crash es6Tweet configuration/sponsor'] = test =>
+{
+    test.expect(10);
+    const sponsor = tart.es6Tweet();
+
+    const crashingActor = count =>
+    {
+        return message =>
+        {
+            count--;
+            test.ok(true);
+            if (count > 0)
+            {
+                throw new Error("boom!");
+            }
+            test.done();
+        };
+    };
+
+    const crasher = sponsor(crashingActor(10));
+
+    for (let i = 0; i < 10; i++)
+    {
+        crasher('explode');
+    }
+};
 
 test['actor crash should not crash the configuration/sponsor'] = function (test) {
     test.expect(10);


### PR DESCRIPTION
This pull request introduces ES6 to the repository and requires Node.js v4.1.0 or greater as a consequence. Additionally, a more robust implementation of tweetable TartJS configuration/sponsor is now possible due to terser ES6 syntax.
